### PR TITLE
fix: segmentation fault crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ build/ported-linux_amd64: ${SRCS} ${GEN_SRCS}
 	upx $@
 build/ported-darwin: ${SRCS} ${GEN_SRCS}
 	GOOS=darwin GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o $@ ${SRCS} ${GEN_SRCS}
-	upx $@
 
 ported_all:
 	cd ./porter; $(MAKE) all


### PR DESCRIPTION
fixes issue #34 

the segmentation fault is due to upx compression of the binary

issue with upx mentioned in https://github.com/upx/upx/issues/612